### PR TITLE
Update default model repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,12 +96,12 @@ SteadyText provides deterministic text generation and embedding with zero config
 ### Deterministic Design
 
 **Text Generation:**
-- Uses Qwen1.5-0.5B-Chat (Q4_K_M GGUF) with deterministic sampling parameters
+- Uses openbmb.BitCPM4-1B.Q8_0.gguf with deterministic sampling parameters
 - Fallback generates text using hash-based word selection when model unavailable
 - Always returns strings, never raises exceptions
 
 **Embeddings:**
-- Uses Qwen1.5-0.5B-Chat (Q8_0 GGUF) configured for embeddings
+- Uses Qwen3-Embedding-0.6B-Q8_0.gguf configured for embeddings
 - Always returns 1024-dimensional L2-normalized float32 numpy arrays
 - Fallback returns zero vectors when model unavailable
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install steadytext
 ```
 
 Models will be downloaded automatically to your local cache directory (e.g., `~/.cache/steadytext/models`) the first time you call `generate()` or `embed()`. This is a one-time download.
-The generation model is ~287MB (Qwen1.5-0.5B-Chat Q4_K_M GGUF).
-The embedding model is ~550MB (Qwen1.5-0.5B-Chat Q8_0 GGUF).
+The generation model is ~1.3GB (openbmb.BitCPM4-1B.Q8_0.gguf).
+The embedding model is ~610MB (Qwen3-Embedding-0.6B-Q8_0.gguf).
 
 *(Further sections like 'How It Works', 'API Reference', 'Contributing', 'License' would be added here)*

--- a/steadytext/utils.py
+++ b/steadytext/utils.py
@@ -22,9 +22,9 @@ if not logger.handlers:
 logger.setLevel(logging.INFO)
 
 # --- Model Configuration ---
-DEFAULT_GENERATION_MODEL_REPO = "Qwen/Qwen3-0.6B-GGUF"
+DEFAULT_GENERATION_MODEL_REPO = "DevQuasar/openbmb.BitCPM4-1B-GGUF"
 DEFAULT_EMBEDDING_MODEL_REPO = "Qwen/Qwen3-Embedding-0.6B-GGUF"
-GENERATION_MODEL_FILENAME = "Qwen3-0.6B-Q8_0.gguf"
+GENERATION_MODEL_FILENAME = "openbmb.BitCPM4-1B.Q8_0.gguf"
 EMBEDDING_MODEL_FILENAME = "Qwen3-Embedding-0.6B-Q8_0.gguf"
 
 # --- Determinism & Seeds ---


### PR DESCRIPTION
## Summary
- switch default generation repo to `DevQuasar/openbmb.BitCPM4-1B-GGUF`
- document new generator and embedder models

## Testing
- `STEADYTEXT_ALLOW_MODEL_DOWNLOADS=false pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb7da0b6c8321a76430ecd1893791