### PR TITLE
Update GitHub Actions to Python 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   format-lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-release-candidate.yaml
+++ b/.github/workflows/test-release-candidate.yaml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         include:
           - os: macos-latest
             python-version: "3.12"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         include:
           - os: windows-latest
             python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 license = { file="LICENSE" }
 requires-python = ">=3.10"
+# AIDEV-NOTE: Only Python 3.10-3.12 are supported for now
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -19,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
## Summary
- update CI workflow to test Python 3.10-3.12
- trim old versions from test workflows
- clean up release candidate matrix
- drop Python 3.13 classifier
- note supported versions in pyproject

## Testing
- `pre-commit run --files pyproject.toml .github/workflows/ci.yml .github/workflows/test.yaml .github/workflows/test-release-candidate.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed54860788321b0b4e1ac79e52d04